### PR TITLE
cocotb2: test/Makefile make more consistent with previous TT editions

### DIFF
--- a/test/Makefile
+++ b/test/Makefile
@@ -10,13 +10,16 @@ PROJECT_SOURCES = project.v
 ifneq ($(GATES),yes)
 
 # RTL simulation:
-SIM_BUILD				= sim_build/rtl
+SIM_BUILD       = sim_build/rtl
 VERILOG_SOURCES += $(addprefix $(SRC_DIR)/,$(PROJECT_SOURCES))
+COMPILE_ARGS    += -DCOCOTB_SIM=1
+COMPILE_ARGS    += -DSIM
 
 else
 
 # Gate level simulation:
-SIM_BUILD				= sim_build/gl
+SIM_BUILD       = sim_build/gl
+COMPILE_ARGS    += -DCOCOTB_SIM=1
 COMPILE_ARGS    += -DGL_TEST
 COMPILE_ARGS    += -DFUNCTIONAL
 COMPILE_ARGS    += -DUSE_POWER_PINS
@@ -31,11 +34,11 @@ VERILOG_SOURCES += $(PWD)/gate_level_netlist.v
 endif
 
 # Allow sharing configuration between design and testbench via `include`:
-COMPILE_ARGS 		+= -I$(SRC_DIR)
+COMPILE_ARGS    += -I$(SRC_DIR)
 
 # Include the testbench sources:
 VERILOG_SOURCES += $(PWD)/tb.v
-TOPLEVEL = tb
+COCOTB_TOPLEVEL = tb
 
 # List test modules to run, separated by commas and without the .py suffix:
 COCOTB_TEST_MODULES = test


### PR DESCRIPTION
Restore COCOTB_SIM=1 like before, this may have been implictly set in cocotb1 and is now explicit.

Added SIM for both pre-synth and post-synth simulation.  GL_TEST exists to detect

Cleanup use of consistent whitespace.